### PR TITLE
fix(manage-tags): fix ordering on manage tags fragment

### DIFF
--- a/android/app/src/main/java/io/github/mattlavallee/checksandbalances/ui/tags/ManageTagsFragment.kt
+++ b/android/app/src/main/java/io/github/mattlavallee/checksandbalances/ui/tags/ManageTagsFragment.kt
@@ -24,7 +24,7 @@ class ManageTagsFragment: Fragment() {
 
         tagViewModel.getAllTagsWithTransactions().observe(viewLifecycleOwner, Observer { itList ->
             binding.manageTagsGroup.removeAllViews()
-            itList.forEach {
+            itList.sortedBy { it.tag.name.lowercase() }.forEach {
                 val activeTransactions = it.transactions.count { t -> t.isActive }
                 val chip = Chip(requireActivity()).apply {
                     text = getString(R.string.manage_tags_label, it.tag.name, activeTransactions)

--- a/android/app/src/main/res/layout/layout_manage_tag_form.xml
+++ b/android/app/src/main/res/layout/layout_manage_tag_form.xml
@@ -20,7 +20,6 @@
         android:id="@+id/edit_tag_name_wrapper"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/edit_tag_title"
         app:hintTextColor="@color/colorOnSecondary"
         app:boxStrokeColor="@color/colorOnSecondary"
         app:layout_constraintTop_toBottomOf="@id/edit_tag_title"


### PR DESCRIPTION
Making it easier to manage tags by displaying said tags in alphabetical order.
Also getting rid of the double "edit tag" display in the tag bottomsheet